### PR TITLE
Alinad exchange link token for public token

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -23,6 +23,7 @@
         "moment": "^2.30.1",
         "morgan": "^1.10.0",
         "plaid": "^23.0.0",
+        "react-plaid-link": "^3.5.1",
         "ts-command-line-args": "^2.5.1"
       },
       "devDependencies": {
@@ -2843,6 +2844,11 @@
         "express": "^4.18.2"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -3238,6 +3244,17 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
       }
     },
     "node_modules/lru-cache": {
@@ -3830,6 +3847,16 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -3916,6 +3943,58 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/react-plaid-link": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/react-plaid-link/-/react-plaid-link-3.5.1.tgz",
+      "integrity": "sha512-OSbPVEIQY3RDroDGyimRh9vUpZfSVzKVCwrbGOSIjcmluHnPKTkvJ1BnYbvE7kH+v8urJXMHloV43uMTNY3SLg==",
+      "dependencies": {
+        "prop-types": "^15.7.2",
+        "react-script-hook": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-script-hook": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/react-script-hook/-/react-script-hook-1.7.2.tgz",
+      "integrity": "sha512-fhyCEfXb94fag34UPRF0zry1XGwmVY+79iibWwTqAoOiCzYJQOYTiWJ7CnqglA9tMSV8g45cQpHCMcBwr7dwhA==",
+      "peerDependencies": {
+        "react": "^16.8.6 || 17 - 18",
+        "react-dom": "^16.8.6 || 17 - 18"
       }
     },
     "node_modules/readdirp": {
@@ -4141,6 +4220,15 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
     },
     "node_modules/semver": {
       "version": "7.6.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -46,6 +46,7 @@
     "moment": "^2.30.1",
     "morgan": "^1.10.0",
     "plaid": "^23.0.0",
+    "react-plaid-link": "^3.5.1",
     "ts-command-line-args": "^2.5.1"
   },
   "devDependencies": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,7 +12,8 @@
         "@emotion/styled": "^11.11.5",
         "@mui/material": "^5.15.17",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "react-plaid-link": "^3.5.1"
       },
       "devDependencies": {
         "@types/react": "^18.2.66",
@@ -3861,6 +3862,19 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
     },
+    "node_modules/react-plaid-link": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/react-plaid-link/-/react-plaid-link-3.5.1.tgz",
+      "integrity": "sha512-OSbPVEIQY3RDroDGyimRh9vUpZfSVzKVCwrbGOSIjcmluHnPKTkvJ1BnYbvE7kH+v8urJXMHloV43uMTNY3SLg==",
+      "dependencies": {
+        "prop-types": "^15.7.2",
+        "react-script-hook": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
@@ -3868,6 +3882,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-script-hook": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/react-script-hook/-/react-script-hook-1.7.2.tgz",
+      "integrity": "sha512-fhyCEfXb94fag34UPRF0zry1XGwmVY+79iibWwTqAoOiCzYJQOYTiWJ7CnqglA9tMSV8g45cQpHCMcBwr7dwhA==",
+      "peerDependencies": {
+        "react": "^16.8.6 || 17 - 18",
+        "react-dom": "^16.8.6 || 17 - 18"
       }
     },
     "node_modules/react-transition-group": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,8 @@
     "@emotion/styled": "^11.11.5",
     "@mui/material": "^5.15.17",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-plaid-link": "^3.5.1"
   },
   "devDependencies": {
     "@types/react": "^18.2.66",

--- a/frontend/src/Context/index.ts
+++ b/frontend/src/Context/index.ts
@@ -1,5 +1,5 @@
 export interface LinkTokenData {
-    'expiration': Date,
-    'link_token':string,
-    'request_id':string
-  }
+  expiration: Date
+  link_token: string
+  request_id: string
+}

--- a/frontend/src/pages/AuthenticatedHomePage.tsx
+++ b/frontend/src/pages/AuthenticatedHomePage.tsx
@@ -14,25 +14,24 @@ import {
 } from '@mui/material'
 
 export function AuthenticatedHomePage() {
-
   //Store the LinkToken
   const [LinkToken, setLinkToken] = useState<LinkTokenData>()
 
   const config: Parameters<typeof usePlaidLink>[0] = {
     token: LinkToken?.link_token!,
-    onSuccess : (token:string, metadata: PlaidLinkOnSuccessMetadata)=>{ alert(`Token: ${token}`) },
+    onSuccess: (token: string, metadata: PlaidLinkOnSuccessMetadata) => {
+      alert(`Token: ${token}`)
+    },
   }
-  
+
   const { open, ready } = usePlaidLink(config)
-
-
 
   useEffect(() => {
     if (ready) {
-      open();
+      open()
     }
-  }, [ready, open]);
-  
+  }, [ready, open])
+
   // Retrieve Link Token from Backend and log it in the browser
   const connectBankClicked = async () => {
     const response = await fetch(

--- a/frontend/src/pages/AuthenticatedHomePage.tsx
+++ b/frontend/src/pages/AuthenticatedHomePage.tsx
@@ -18,20 +18,17 @@ export function AuthenticatedHomePage() {
   const [LinkToken, setLinkToken] = useState<LinkTokenData>()
 
   const onSuccess=(_props: string) =>{};
-  
-  useEffect(() => {
-    
-    const config: Parameters<typeof usePlaidLink>[0] = {
-      token: LinkToken?.link_token!,
-      onSuccess,
-    }
-     const { open, ready } = usePlaidLink(config)
-    
-    if(ready){
-      open();
-    }
-    
-  }, [LinkToken]);
+
+  const config: Parameters<typeof usePlaidLink>[0] = {
+    token: LinkToken?.link_token!,
+    onSuccess,
+  }
+
+  const { open, ready } = usePlaidLink(config)
+
+  if(ready){
+    open();
+  }
   
   // Retrieve Link Token from Backend and log it in the browser
   const connectBankClicked = async () => {

--- a/frontend/src/pages/AuthenticatedHomePage.tsx
+++ b/frontend/src/pages/AuthenticatedHomePage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { LinkTokenData } from '../Context'
-import { usePlaidLink } from 'react-plaid-link'
+import { PlaidLinkOnSuccessMetadata, usePlaidLink } from 'react-plaid-link'
 
 import {
   Box,
@@ -17,18 +17,20 @@ export function AuthenticatedHomePage() {
   //Store the LinkToken
   const [LinkToken, setLinkToken] = useState<LinkTokenData>()
 
-  const onSuccess=(_props: string) =>{};
-
   const config: Parameters<typeof usePlaidLink>[0] = {
     token: LinkToken?.link_token!,
-    onSuccess,
+    onSuccess : (token:string, metadata: PlaidLinkOnSuccessMetadata)=>{ console.log(`Token: ${token}`) },
   }
-
+  
   const { open, ready } = usePlaidLink(config)
 
-  if(ready){
-    open();
-  }
+
+
+  useEffect(() => {
+    if (ready) {
+      open();
+    }
+  }, [ready, open]);
   
   // Retrieve Link Token from Backend and log it in the browser
   const connectBankClicked = async () => {

--- a/frontend/src/pages/AuthenticatedHomePage.tsx
+++ b/frontend/src/pages/AuthenticatedHomePage.tsx
@@ -14,12 +14,13 @@ import {
 } from '@mui/material'
 
 export function AuthenticatedHomePage() {
+
   //Store the LinkToken
   const [LinkToken, setLinkToken] = useState<LinkTokenData>()
 
   const config: Parameters<typeof usePlaidLink>[0] = {
     token: LinkToken?.link_token!,
-    onSuccess : (token:string, metadata: PlaidLinkOnSuccessMetadata)=>{ console.log(`Token: ${token}`) },
+    onSuccess : (token:string, metadata: PlaidLinkOnSuccessMetadata)=>{ alert(`Token: ${token}`) },
   }
   
   const { open, ready } = usePlaidLink(config)

--- a/frontend/src/pages/AuthenticatedHomePage.tsx
+++ b/frontend/src/pages/AuthenticatedHomePage.tsx
@@ -1,5 +1,6 @@
-import { useState } from "react";
-import { LinkTokenData } from "../Context";
+import { useEffect, useState } from 'react'
+import { LinkTokenData } from '../Context'
+import { usePlaidLink } from 'react-plaid-link'
 
 import {
   Box,
@@ -12,13 +13,25 @@ import {
   Typography,
 } from '@mui/material'
 
-
-
-
 export function AuthenticatedHomePage() {
-
   //Store the LinkToken
-  const[LinkToken, setLinkToken] = useState<LinkTokenData>();
+  const [LinkToken, setLinkToken] = useState<LinkTokenData>()
+
+  const onSuccess=(_props: string) =>{};
+  
+  useEffect(() => {
+    
+    const config: Parameters<typeof usePlaidLink>[0] = {
+      token: LinkToken?.link_token!,
+      onSuccess,
+    }
+     const { open, ready } = usePlaidLink(config)
+    
+    if(ready){
+      open();
+    }
+    
+  }, [LinkToken]);
   
   // Retrieve Link Token from Backend and log it in the browser
   const connectBankClicked = async () => {
@@ -26,8 +39,8 @@ export function AuthenticatedHomePage() {
       'http://localhost:3000/api/banking/create_link_token',
       { method: 'Get' },
     )
-    const linkData = await response.json() as LinkTokenData;
-    setLinkToken(linkData);
+    const linkData = (await response.json()) as LinkTokenData
+    setLinkToken(linkData)
   }
 
   return (


### PR DESCRIPTION
### Problem 
Link Token needs to be sent to Plaid and a Public Token needs to be returned to the Frontend

### Solution
Use Plaid Client to send Link Token and `onSuccess` function to receive the Public Token

### Testing
Link Token was successfully sent to Plaid when the initial login-pages appeared
Public Token was successfully received by the frontend when a public token was displayed via an alert message