### PR TITLE
Exchanging Public Token for Access Token

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -23,6 +23,7 @@
         "moment": "^2.30.1",
         "morgan": "^1.10.0",
         "plaid": "^23.0.0",
+        "pretty-print-json": "^3.0.1",
         "react-plaid-link": "^3.5.1",
         "ts-command-line-args": "^2.5.1"
       },
@@ -3846,6 +3847,11 @@
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
+    },
+    "node_modules/pretty-print-json": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/pretty-print-json/-/pretty-print-json-3.0.1.tgz",
+      "integrity": "sha512-AA2h0aq55ygYn0+Igpdw59YTa+TEvMr4X8U3WSsWIQIjiwxeSH1YspVd/xFf1X/B8WxtmjPDbX+h7eGHQS/whw=="
     },
     "node_modules/prop-types": {
       "version": "15.8.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -46,6 +46,7 @@
     "moment": "^2.30.1",
     "morgan": "^1.10.0",
     "plaid": "^23.0.0",
+    "pretty-print-json": "^3.0.1",
     "react-plaid-link": "^3.5.1",
     "ts-command-line-args": "^2.5.1"
   },

--- a/backend/src/models/Banking.ts
+++ b/backend/src/models/Banking.ts
@@ -1,4 +1,3 @@
 export interface IPublicToken {
   publicToken: string
-  dirtyToken: number
 }

--- a/backend/src/routes/BankingRoutes.ts
+++ b/backend/src/routes/BankingRoutes.ts
@@ -1,6 +1,7 @@
 import { IPublicToken } from '@src/models/Banking'
 import { IReq, IRes } from './types/express/misc'
 import { BankingRoutesLinkData } from '@src/Context'
+const util = require('util')
 
 require('dotenv').config()
 const {
@@ -13,6 +14,8 @@ const {
 const PLAID_CLIENT_ID = process.env.PLAID_CLIENT_ID
 const PLAID_SECRET = process.env.PLAID_SECRET
 const PLAID_ENV = 'sandbox'
+
+let ACCESS_TOKEN = null
 
 // PLAID_PRODUCTS is a comma-separated list of products to use when initializing
 // Link. Note that this list must contain 'assets' in order for the app to be
@@ -65,10 +68,18 @@ async function get(_: IReq, res: IRes) {
   console.log(data)
   res.json(data)
 }
+const prettyPrintResponse = (response: any) => {
+  console.log(util.inspect(response.data, { colors: true, depth: 4 }))
+}
+// Send the Public Token to Plaid in exchange for an "Access Token"
 
 async function put(req: IReq<IPublicToken>, res: IRes) {
-  console.log(req.body)
-  res.send(JSON.stringify(req.body.publicToken))
+  const tokenResponse = await client.itemPublicTokenExchange({
+    public_token: req.body.publicToken,
+  })
+
+  prettyPrintResponse(tokenResponse)
+  ACCESS_TOKEN = tokenResponse.data.access_token
 }
 
 export default {

--- a/frontend/src/pages/AuthenticatedHomePage.tsx
+++ b/frontend/src/pages/AuthenticatedHomePage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { LinkTokenData } from '../Context'
-import { PlaidLinkOnSuccessMetadata, usePlaidLink } from 'react-plaid-link'
+import { usePlaidLink } from 'react-plaid-link'
 
 import {
   Box,
@@ -19,8 +19,16 @@ export function AuthenticatedHomePage() {
 
   const config: Parameters<typeof usePlaidLink>[0] = {
     token: LinkToken?.link_token!,
-    onSuccess: (token: string, metadata: PlaidLinkOnSuccessMetadata) => {
-      alert(`Token: ${token}`)
+    onSuccess: async (token: string) => {
+
+        const response = await fetch("http://localhost:3000/api/banking/send_public_token", {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({publicToken:`${token}`})
+        });
+        console.log(await response.json());
     },
   }
 


### PR DESCRIPTION
## Problem

Output wasn't printing nicely, and unneeded parameters were part of the `IPublicToken` interface. Additionally, there was no way to store the Access Token and send the Public Token to the backend

## Solution
Installed `Pretty Print` and removed the dirty token parameter. Additionally, a variable was created to store the Access Token and the OnSuccess method was modified to send the `Public Token` to the backend

## Testing
Postman and Console